### PR TITLE
Fix ideviceinstaller terminating prematurely on windows

### DIFF
--- a/src/ideviceinstaller.c
+++ b/src/ideviceinstaller.c
@@ -349,10 +349,10 @@ static void idevice_wait_for_command_to_complete()
 	struct timespec ts;
 	ts.tv_sec = 0;
 	ts.tv_nsec = 50000000;
-	is_device_connected = 1;
 #else
     unsigned long sleep_duration = 500;
 #endif
+	is_device_connected = 1;
 
 	/* subscribe to make sure to exit on device removal */
 	idevice_event_subscribe(idevice_event_callback, NULL);


### PR DESCRIPTION
When using ideviceinstaller on windows, a change caused is_device_connected to not be set when WIN32 is defined. This means that as soon as libimobiledevice returns information, ideviceinstaller considers the device disconnected and terminates. Checking afterwards will show that the app is not installed, but if you wait, the application will get installed anyway. This fix returns is_device_connected outside of its macro, which makes ideviceinstaller waits until the app is actually installed or the device is disconnected.
